### PR TITLE
Disable caching for maintenance page

### DIFF
--- a/nginx/conf/includes/404.conf
+++ b/nginx/conf/includes/404.conf
@@ -1,4 +1,7 @@
 error_page 404 /index.html;
 location = /index.html {
   internal;
+  add_header 'Cache-Control' 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0' always;
+  expires off;
+  proxy_no_cache 1;
 }


### PR DESCRIPTION
Disable caching so when the maintenance route has been unmapped then we
should always go to the new route rather than loading cache.