### PR TITLE
updating wording to service unavailable

### DIFF
--- a/app/templates/src/unplanned-maintenance.html
+++ b/app/templates/src/unplanned-maintenance.html
@@ -1,10 +1,10 @@
 {% extends 'src/main.html' %}
-{% block title %}Unplanned Downtime{% endblock %}
+{% block title %}Service Unavailable{% endblock %}
 {% block main %}
 <div class="grid">
     <div class="grid__col col-8@m">
         <main id="main-content" class="page__main" role="main">
-            <h1>Unplanned downtime</h1>
+            <h1>Service Unavailable</h1>
             <p>We are currently experiencing technical difficulties. Our engineers are investigating and hope to have the service back up shortly.</p>
             <p>Thank you for your patience.</p>
         </main>

--- a/tests/views/test_maintenance.py
+++ b/tests/views/test_maintenance.py
@@ -21,7 +21,7 @@ class TestMaintenance(unittest.TestCase):
         Config.MAINTENANCE_TEMPLATE = 'UNPLANNED_MAINTENANCE'
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
-        self.assertTrue('Unplanned downtime'.encode() in response.data)
+        self.assertTrue('Service Unavailable'.encode() in response.data)
 
 
 


### PR DESCRIPTION
# Motivation and Context


# What has changed
Wording for unplanned maintenance now says service unavailable

# How to test?
Check that the wording has been changed from unplanned downtime to service unavailable

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
