### PR TITLE
Band-aid fix for routes.

### DIFF
--- a/app/views/maintenance.py
+++ b/app/views/maintenance.py
@@ -8,7 +8,7 @@ MAINTENANCE_TEMPLATES = {"UNPLANNED_MAINTENANCE": "src/unplanned-maintenance.htm
                          "SERVICE_UNAVAILABLE": "src/service-unavailable.html"}
 
 
-# Lots of options as a temporary fill in.
+# Hardcode the most common routes until we find a wildcard solution
 @maintenance_blueprint.route('/')
 @maintenance_blueprint.route('/sign-in')
 @maintenance_blueprint.route('/sign-in/')

--- a/app/views/maintenance.py
+++ b/app/views/maintenance.py
@@ -8,7 +8,12 @@ MAINTENANCE_TEMPLATES = {"UNPLANNED_MAINTENANCE": "src/unplanned-maintenance.htm
                          "SERVICE_UNAVAILABLE": "src/service-unavailable.html"}
 
 
+# Lots of options as a temporary fill in.
 @maintenance_blueprint.route('/')
+@maintenance_blueprint.route('/sign-in')
+@maintenance_blueprint.route('/sign-in/')
+@maintenance_blueprint.route('/surveys/todo')
+@maintenance_blueprint.route('/surveys/todo/')
 def maintenance():
     template = MAINTENANCE_TEMPLATES.get(Config.MAINTENANCE_TEMPLATE)
 


### PR DESCRIPTION
# Motivation and Context
Some people accessing maintenance page would see a 404 because the url wasn't `/`.

# What has changed
Added several extra routes to cover commonly used pages.

# How to test?
Start solutioon, confirm that page loads for
`/sign-in`
`/surveys/todo`
