### PR TITLE
Catch all route

### DIFF
--- a/app/views/maintenance.py
+++ b/app/views/maintenance.py
@@ -8,13 +8,9 @@ MAINTENANCE_TEMPLATES = {"UNPLANNED_MAINTENANCE": "src/unplanned-maintenance.htm
                          "SERVICE_UNAVAILABLE": "src/service-unavailable.html"}
 
 
-# Hardcode the most common routes until we find a wildcard solution
-@maintenance_blueprint.route('/')
-@maintenance_blueprint.route('/sign-in')
-@maintenance_blueprint.route('/sign-in/')
-@maintenance_blueprint.route('/surveys/todo')
-@maintenance_blueprint.route('/surveys/todo/')
-def maintenance():
+@maintenance_blueprint.route('/', defaults={ 'path': '' })
+@maintenance_blueprint.route('/<path:path>')
+def maintenance(path):
     template = MAINTENANCE_TEMPLATES.get(Config.MAINTENANCE_TEMPLATE)
 
     if template is None:

--- a/app/views/maintenance.py
+++ b/app/views/maintenance.py
@@ -7,10 +7,10 @@ maintenance_blueprint = Blueprint(name='Maintenance', import_name=__name__, url_
 MAINTENANCE_TEMPLATES = {"UNPLANNED_MAINTENANCE": "src/unplanned-maintenance.html",
                          "SERVICE_UNAVAILABLE": "src/service-unavailable.html"}
 
-
-@maintenance_blueprint.route('/', defaults={ 'path': '' })
-@maintenance_blueprint.route('/<path:path>')
-def maintenance(path):
+# A catch all route in Flask/Werkzeug
+@maintenance_blueprint.route('/', defaults={ 'path': '' })              # Set a default variable 'path' to pass to route handler
+@maintenance_blueprint.route('/<path:path>')                            # Route then expects a variable, defaults to blank if not specified
+def maintenance(path):                                                  # Pass the variable to the handler, even though we don't need it, to avoid error
     template = MAINTENANCE_TEMPLATES.get(Config.MAINTENANCE_TEMPLATE)
 
     if template is None:

--- a/tests/views/test_maintenance.py
+++ b/tests/views/test_maintenance.py
@@ -17,6 +17,11 @@ class TestMaintenance(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('Service temporarily unavailable'.encode() in response.data)
 
+    def test_get_maintenance_page_with_other_route(self):
+        response = self.client.get('/hfkjsdkjsdhjdfkjs/sdflkjshfdkj/skdjf')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Service temporarily unavailable'.encode() in response.data)
+
     def test_get_unplanned_maintenance_page(self):
         Config.MAINTENANCE_TEMPLATE = 'UNPLANNED_MAINTENANCE'
         response = self.client.get('/')


### PR DESCRIPTION
# Motivation and Context
The maintenance page should return the maintenance page view for any path or query string

# What has changed
* route now matches routes with a `path` variable
* `path` variable defaults to blank string, so `/` route still works
* tests updated to test that alternative routes also work

# How to test?
* Run tests
* Spin up solution
* Visit `localhost:8077` to confirm you see maintenance page
* Add some extra path to the end of the URL, and confirm the page still delivers.

# Links
https://trello.com/c/Z4oOFFXS